### PR TITLE
Fixing duplicate notification error

### DIFF
--- a/src/react/components/AddJobFormModel.tsx
+++ b/src/react/components/AddJobFormModel.tsx
@@ -40,6 +40,7 @@ function AddJobFormModel({ isOpen, onClose, onAddJob }: AddJobFormModelProps) {
       setPaymentNote("");
       setIsArchived(false);
       setIsPinned(false);
+      setHasNoDeletedNotification(true);
     }
   }, [isOpen]);
 
@@ -67,7 +68,7 @@ function AddJobFormModel({ isOpen, onClose, onAddJob }: AddJobFormModelProps) {
       paymentNote: paymentNote,
       isArchived: isArchived,
       isPinned: isPinned,
-      hasNoDeletedNotification: hasNoDeletedNotification,
+      hasNoDeletedNotification: true,
     };
 
     onAddJob(newJob);

--- a/src/react/components/JobTable.tsx
+++ b/src/react/components/JobTable.tsx
@@ -437,6 +437,7 @@ function JobTable({
       due: job.due,
       isPinned: isPinned,
       isArchived: job.isArchived,
+      hasNoDeletedNotification: job.hasNoDeletedNotification,
     };
     updateJob(temp);
     window.location.reload();

--- a/src/react/components/NotificationsList.tsx
+++ b/src/react/components/NotificationsList.tsx
@@ -1,4 +1,3 @@
-import { FaShoppingCart, FaThumbtack } from "react-icons/fa";
 import { FaTimes } from "react-icons/fa";
 
 interface Props {
@@ -6,17 +5,13 @@ interface Props {
   onDeleteNotification: (notificationId: string, jobId: string) => void
 }
 
-const iconMap = {
-  cart: <FaShoppingCart className="notif-icon-svg" />,
-  pin: <FaThumbtack className="notif-icon-svg" />,
-};
 
 export default function NotificationsList({ notifsParams, onDeleteNotification }: Props) {
   return (
     <div className="notifications-list">
       {notifsParams.map((notif, index) => (
         <div key={index} className="notification-card">
-          <div className="notif-icon">{iconMap[notif.icon ?? "cart"]}</div>
+          {/* <div className="notif-icon">{iconMap[notif.icon ?? "cart"]}</div> */}
           <div className="notif-content">
             <div className="notif-title">{notif.notifTitle}</div>
             <div className="notif-desc">{notif.notifDesc}</div>


### PR DESCRIPTION
Inconsistent fix for duplicate notification error, but it's resolved by turning off strict mode so it's useless anyway. However, edit job form is modified so that it won't update job when user doesn't modify the form in any way (open form and submitting, change something and go back on it, etc.). DO NOT MERGE.